### PR TITLE
fix(memory) free classic BT memory to heap

### DIFF
--- a/main/src/main.cpp
+++ b/main/src/main.cpp
@@ -37,6 +37,7 @@
 #include "esp_heap_caps.h"
 #include "esp_log.h"
 #include "nvs_flash.h"
+#include "esp_bt.h"
 
 // TODO: driver should be registered by the driver itself.
 // However, the linker will eliminate unreferenced symbols from static libraries.
@@ -382,6 +383,8 @@ app_main()
 
   loopp::utils::memlog("app_main");
   new Main();
+
+  esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);
 
   while (true)
     {


### PR DESCRIPTION
This patch releases the classic (non-BLE) bluetooth memory, which seems to fix #6.  With this change, I've had the scanner running for about 20 minutes so far without a single timeout, although I still see this message at the end of a scan cycle:

```
E (425710) BT_HCI: btu_hcif_hdl_command_complete opcode 0x200b status 0x12
```
